### PR TITLE
docs: download url point the release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 bob插件主要为bob用户开发,bob是一款macOS上的翻译软件,bob官网地址:https://bobtranslate.com/
 
-#### OpenAI ChatGPT免秘钥bob插件下载地址:[OpenAI chatgpt插件(免秘钥,免启动服务)](https://github.com/akl7777777/bob-plugin-akl-chatgpt-free-translate/releases/download/v1.0.1/bob-plugin-akl-chatgpt-free-translate_v1.0.1.bobplugin)
+#### OpenAI ChatGPT免秘钥bob插件下载地址:[OpenAI chatgpt插件(免秘钥,免启动服务)](https://github.com/akl7777777/bob-plugin-akl-chatgpt-free-translate/releases)
 
 使用方法:双击安装,直接使用
 


### PR DESCRIPTION
将Readme中的下载连接指向了Release界面，因为我在使用的时候直接点击了下载连接，但是下载的文件是以前的版本，导致每次都翻译失败，直到我翻看ISSUE才发现我下载的是旧版本，建议将下载链接指向Release界面或者每次更新时同步更新下载链接

=====================================================================================

The download link in Readme points to the Release interface, because I clicked the download link directly when I was using it, but the downloaded file was a previous version, which caused the translation to fail every time, until I looked up ISSUE and found that the version I downloaded was an old one.